### PR TITLE
Check length of array before reducing

### DIFF
--- a/main.js
+++ b/main.js
@@ -1021,14 +1021,16 @@ getValue['comment block'] = function (settings, element, parent) {
         }
       }
     }
-    element.value = v.reduce(function (a, b) {
-      if (b === '\n') {
-        return a += '\n';
-      } else if (a.substr(-1) === '\n') {
-        return a + b;
-      }
-      return a += ' ' + b;
-    }).split('\n');
+    if (v.length > 0) {
+      element.value = v.reduce(function (a, b) {
+        if (b === '\n') {
+          return a += '\n';
+        } else if (a.substr(-1) === '\n') {
+          return a + b;
+        }
+        return a += ' ' + b;
+      }).split('\n');
+    }
   }
   if (settings.lineBreak) {
     lineBreak();


### PR DESCRIPTION
Sometimes, around line 1024, the array named v will be empty,
and trying to reduce an empty array will throw an error. This
is just a quick fix for just that. Here, we check that the
length of v is bigger than 0, and only reduce the array if it
has any elements.